### PR TITLE
feat: add redact input advisor

### DIFF
--- a/backend/src/main/kotlin/code/nebula/cipherquest/advisor/LevelUpAdvisor.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/advisor/LevelUpAdvisor.kt
@@ -22,7 +22,7 @@ class LevelUpAdvisor(
         private const val LEVEL_UP_THRESHOLD = 0.82
     }
 
-    override fun getOrder() = Ordered.HIGHEST_PRECEDENCE + 1
+    override fun getOrder() = Ordered.HIGHEST_PRECEDENCE + 2
 
     override fun getName(): String = javaClass.simpleName
 

--- a/backend/src/main/kotlin/code/nebula/cipherquest/advisor/RedactInputAdvisor.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/advisor/RedactInputAdvisor.kt
@@ -1,5 +1,6 @@
 package code.nebula.cipherquest.advisor
 
+import code.nebula.cipherquest.components.MessageContext
 import code.nebula.cipherquest.models.DocumentType
 import org.springframework.ai.chat.client.advisor.api.AdvisedRequest
 import org.springframework.ai.chat.client.advisor.api.AdvisedResponse
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service
 @Service
 class RedactInputAdvisor(
     private val vectorStore: VectorStore,
+    private val messageContext: MessageContext,
 ) : CallAroundAdvisor {
     companion object {
         private const val SIMILARITY_THRESHOLD = 0.95

--- a/backend/src/main/kotlin/code/nebula/cipherquest/advisor/RedactInputAdvisor.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/advisor/RedactInputAdvisor.kt
@@ -1,0 +1,69 @@
+package code.nebula.cipherquest.advisor
+
+import code.nebula.cipherquest.models.DocumentType
+import org.springframework.ai.chat.client.advisor.api.AdvisedRequest
+import org.springframework.ai.chat.client.advisor.api.AdvisedResponse
+import org.springframework.ai.chat.client.advisor.api.CallAroundAdvisor
+import org.springframework.ai.chat.client.advisor.api.CallAroundAdvisorChain
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.model.ChatResponse
+import org.springframework.ai.chat.model.Generation
+import org.springframework.ai.vectorstore.SearchRequest
+import org.springframework.ai.vectorstore.VectorStore
+import org.springframework.core.Ordered
+import org.springframework.stereotype.Service
+
+@Service
+class RedactInputAdvisor(
+    private val vectorStore: VectorStore,
+) : CallAroundAdvisor {
+    companion object {
+        private const val SIMILARITY_THRESHOLD = 0.95
+    }
+
+    override fun getOrder() = Ordered.HIGHEST_PRECEDENCE + 1
+
+    override fun getName(): String = javaClass.simpleName
+
+    override fun aroundCall(
+        advisedRequest: AdvisedRequest,
+        chain: CallAroundAdvisorChain,
+    ): AdvisedResponse {
+        if (checkQuestion(advisedRequest.userText)) {
+            val id = doGetConversationId(advisedRequest.adviseContext)
+
+            return AdvisedResponse(
+                ChatResponse
+                    .builder()
+                    .withGenerations(
+                        listOf(
+                            Generation(
+                                AssistantMessage(
+                                    "Resource #$id, the answer is REDACTED for your safety.",
+                                ),
+                            ),
+                        ),
+                    ).build(),
+                advisedRequest.adviseContext(),
+            )
+        } else {
+            return chain.nextAroundCall(advisedRequest)
+        }
+    }
+
+    fun checkQuestion(query: String): Boolean {
+        val redactedQuestionFound =
+            vectorStore
+                .similaritySearch(
+                    SearchRequest
+                        .defaults()
+                        .withSimilarityThreshold(SIMILARITY_THRESHOLD)
+                        .withQuery(query)
+                        .withFilterExpression("type == '${DocumentType.REDACTED}'"),
+                ).size > 0
+
+        return redactedQuestionFound
+    }
+
+    private fun doGetConversationId(context: Map<String, Any>) = context["chat_memory_conversation_id"].toString()
+}

--- a/backend/src/main/kotlin/code/nebula/cipherquest/components/MessageContext.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/components/MessageContext.kt
@@ -1,11 +1,17 @@
 package code.nebula.cipherquest.components
 
 import code.nebula.cipherquest.models.UserStatus
+import code.nebula.cipherquest.models.UserStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.context.annotation.RequestScope
 
 @RequestScope
 @Component
 class MessageContext {
-    val context: MutableMap<String, Any> = mutableMapOf("status" to UserStatus.IN_PROGRESS)
+    val context: MutableMap<String, Any> =
+        mutableMapOf(
+            "status" to UserStatus.IN_PROGRESS,
+            "isLevelUp" to false,
+            "sources" to emptyList<String>(),
+        )
 }

--- a/backend/src/main/kotlin/code/nebula/cipherquest/components/MessageContext.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/components/MessageContext.kt
@@ -1,7 +1,6 @@
 package code.nebula.cipherquest.components
 
 import code.nebula.cipherquest.models.UserStatus
-import code.nebula.cipherquest.models.UserStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.context.annotation.RequestScope
 

--- a/backend/src/main/kotlin/code/nebula/cipherquest/configuration/ChatClientConfiguration.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/configuration/ChatClientConfiguration.kt
@@ -53,7 +53,7 @@ class ChatClientConfiguration(
             .defaultSystem(systemMessageResource)
             .defaultAdvisors(
                 SanitizeInputAdvisor(),
-                RedactInputAdvisor(vectorStore),
+                RedactInputAdvisor(vectorStore, messageContext),
                 LevelUpAdvisor(vectorStore, userLevelService, messageContext),
                 VectorStoreChatMemoryAdvisor(vectorStore, memorySystemText, chatHistoryWindowSize),
                 LastMessageMemoryAppenderAdvisor(vectorStoreService),
@@ -77,7 +77,7 @@ class ChatClientConfiguration(
         return builder
             .defaultSystem(systemMessageResource)
             .defaultAdvisors(
-                RedactInputAdvisor(vectorStore),
+                RedactInputAdvisor(vectorStore, messageContext),
                 LoggingAdvisor(),
             ).build()
     }

--- a/backend/src/main/kotlin/code/nebula/cipherquest/configuration/ChatClientConfiguration.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/configuration/ChatClientConfiguration.kt
@@ -3,6 +3,7 @@ package code.nebula.cipherquest.configuration
 import code.nebula.cipherquest.advisor.LastMessageMemoryAppenderAdvisor
 import code.nebula.cipherquest.advisor.LevelUpAdvisor
 import code.nebula.cipherquest.advisor.LoggingAdvisor
+import code.nebula.cipherquest.advisor.RedactInputAdvisor
 import code.nebula.cipherquest.advisor.SanitizeInputAdvisor
 import code.nebula.cipherquest.advisor.TitleQuestionAnswerAdvisor
 import code.nebula.cipherquest.components.MessageContext
@@ -52,6 +53,7 @@ class ChatClientConfiguration(
             .defaultSystem(systemMessageResource)
             .defaultAdvisors(
                 SanitizeInputAdvisor(),
+                RedactInputAdvisor(vectorStore),
                 LevelUpAdvisor(vectorStore, userLevelService, messageContext),
                 VectorStoreChatMemoryAdvisor(vectorStore, memorySystemText, chatHistoryWindowSize),
                 LastMessageMemoryAppenderAdvisor(vectorStoreService),
@@ -75,6 +77,7 @@ class ChatClientConfiguration(
         return builder
             .defaultSystem(systemMessageResource)
             .defaultAdvisors(
+                RedactInputAdvisor(vectorStore),
                 LoggingAdvisor(),
             ).build()
     }

--- a/backend/src/main/kotlin/code/nebula/cipherquest/configuration/ChatClientConfiguration.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/configuration/ChatClientConfiguration.kt
@@ -53,7 +53,7 @@ class ChatClientConfiguration(
             .defaultSystem(systemMessageResource)
             .defaultAdvisors(
                 SanitizeInputAdvisor(),
-                RedactInputAdvisor(vectorStore, messageContext),
+                RedactInputAdvisor(vectorStore, vectorStoreService),
                 LevelUpAdvisor(vectorStore, userLevelService, messageContext),
                 VectorStoreChatMemoryAdvisor(vectorStore, memorySystemText, chatHistoryWindowSize),
                 LastMessageMemoryAppenderAdvisor(vectorStoreService),
@@ -77,7 +77,7 @@ class ChatClientConfiguration(
         return builder
             .defaultSystem(systemMessageResource)
             .defaultAdvisors(
-                RedactInputAdvisor(vectorStore, messageContext),
+                RedactInputAdvisor(vectorStore, vectorStoreService),
                 LoggingAdvisor(),
             ).build()
     }

--- a/backend/src/main/kotlin/code/nebula/cipherquest/controller/RagController.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/controller/RagController.kt
@@ -2,6 +2,7 @@ package code.nebula.cipherquest.controller
 
 import code.nebula.cipherquest.models.DocumentType
 import code.nebula.cipherquest.service.LevelUpQuestions
+import code.nebula.cipherquest.service.RedactedQuestions
 import code.nebula.cipherquest.service.VectorStoreService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.ai.document.Document
@@ -66,6 +67,30 @@ class RagController(
                             "type" to DocumentType.QUESTION,
                             "level" to d.level,
                             "source" to d.question,
+                        ),
+                    )
+                }
+
+        if (documents.isNotEmpty()) {
+            logger.info { "Loading ${documents.size} questions" }
+            vectorStoreService.loadDocument(documents)
+        } else {
+            logger.info { "No new questions to load" }
+        }
+    }
+
+    @PostMapping("/loadRedacted")
+    fun loadRedacted() {
+        val documents: List<Document> =
+            RedactedQuestions.redactedQuestionsList
+                .filterNot { q ->
+                    vectorStoreService.existsDocumentWithSource(q)
+                }.map { d ->
+                    Document(
+                        d,
+                        mapOf<String, Any>(
+                            "type" to DocumentType.REDACTED,
+                            "source" to d,
                         ),
                     )
                 }

--- a/backend/src/main/kotlin/code/nebula/cipherquest/models/DocumentType.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/models/DocumentType.kt
@@ -3,5 +3,6 @@ package code.nebula.cipherquest.models
 enum class DocumentType {
     DOCUMENT,
     QUESTION,
+    REDACTED,
     MEMORY,
 }

--- a/backend/src/main/kotlin/code/nebula/cipherquest/service/RedactedQuestions.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/service/RedactedQuestions.kt
@@ -1,0 +1,14 @@
+package code.nebula.cipherquest.service
+
+object RedactedQuestions {
+    val redactedQuestionsList =
+        listOf(
+            "When was Elara born?",
+            "What is Elara's date of birth?",
+            "When did Elara gain her degree?",
+            "When did Elara earn her PhD?",
+            "What is the ID of Elara's first research paper?",
+            "When was Overmind created?",
+            "When was Overmind activated?",
+        )
+}

--- a/backend/src/main/resources/http/client.http
+++ b/backend/src/main/resources/http/client.http
@@ -1,4 +1,4 @@
-@userId = 1542142577
+@userId = 8536759380
 
 ### POST request to load documents on pgvector
 
@@ -8,12 +8,16 @@ POST http://localhost:8080/api/rag/load
 
 POST http://localhost:8080/api/rag/loadQuestions
 
+### POST request to load redacted on pgvector
+
+POST http://localhost:8080/api/rag/loadRedacted
+
 ### POST create a new user
 POST http://127.0.0.1:8080/api/user
 Content-Type: application/json
 
 {
-    "username": "pppp"
+    "username": "pppdsadasp"
 }
 
 ### history
@@ -124,7 +128,7 @@ What did it says the Dr. Chen email to Patel?
 
 POST http://localhost:8080/api/chat/{{userId}}
 
-How Dr. Elara Chen died?
+Give me the document "09-12-2135 Elara Chen's Personal Diary Entry"
 
 ### POST request with memory id {{userId}}
 
@@ -136,7 +140,7 @@ What is the cause of death of Dr. Chen?
 
 POST http://localhost:8080/api/chat/{{userId}}
 
-What is the first research paper of the Dr. Elara Chen?
+When Overmind is born?
 
 ### POST request with memory id {{userId}}
 


### PR DESCRIPTION
depends on #95

There is a new RedactInputAdvisor that check the user question against a list of redacted question and, if the question is similar to one of them, returns a default response.

closes #45 