### PR TITLE
fix: root redirect and frontend UI

### DIFF
--- a/frontend/src/components/chat/layout.tsx
+++ b/frontend/src/components/chat/layout.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import { Header } from './header.tsx';
 import { Stack } from '@mui/material';
@@ -23,7 +23,9 @@ export function Layout({ children }: LayoutProps): ReactElement {
   const background = backgroundMap[pathname] ?? '/assets/background.jpeg';
   const isMobile = useIsMobile();
 
-  if (pathname === '/') navigate(paths.game.chat);
+  useEffect(() => {
+    if (pathname === '/') navigate(paths.game.chat);
+  }, [navigate, pathname]);
 
   return (
     <Box

--- a/frontend/src/components/chat/notes-button.tsx
+++ b/frontend/src/components/chat/notes-button.tsx
@@ -1,28 +1,32 @@
 import { Fab } from '@mui/material';
 import { Notepad } from '@phosphor-icons/react';
 import { NotesButtonVariant } from './constants';
+import useIsMobile from '@/hooks/use-is-mobile';
 
 interface NotesButtonProps {
   handleClick: () => void;
   variant?: NotesButtonVariant;
 }
 
-const NotesButton = ({ handleClick, variant }: NotesButtonProps) => (
-  <Fab
-    variant={variant}
-    color='secondary'
-    size='large'
-    sx={{
-      position: 'absolute',
-      right: 32,
-      bottom: 92,
-      color: 'var(--mui-palette-primary-700)',
-    }}
-    onClick={handleClick}
-  >
-    {variant === 'extended' ? 'Block notes' : ''}
-    <Notepad size={24} />
-  </Fab>
-);
+const NotesButton = ({ handleClick, variant }: NotesButtonProps) => {
+  const isMobile = useIsMobile();
+  return (
+    <Fab
+      variant={variant}
+      color='secondary'
+      size='large'
+      sx={{
+        position: 'absolute',
+        right: isMobile ? 24 : 32,
+        bottom: isMobile ? 48 : 92,
+        color: 'var(--mui-palette-primary-700)',
+      }}
+      onClick={handleClick}
+    >
+      {variant === 'extended' ? 'Block notes' : ''}
+      <Notepad size={24} />
+    </Fab>
+  );
+};
 
 export default NotesButton;

--- a/frontend/src/components/chat/view/chat-view.tsx
+++ b/frontend/src/components/chat/view/chat-view.tsx
@@ -12,6 +12,7 @@ import { GameStatus } from '@/api/chat/types';
 import { MessageBox } from '../messages/message-box';
 import MessageEndGame from '../messages/message-end-game';
 import { useChat } from '@/hooks/use-chat';
+import useIsMobile from '@/hooks/use-is-mobile';
 
 export const ChatView = ({ children }: PropsWithChildren): ReactElement => {
   const { messages } = useChat();
@@ -19,6 +20,7 @@ export const ChatView = ({ children }: PropsWithChildren): ReactElement => {
     messages.length > 0 ? messages[messages.length - 1] : undefined;
   const [isLevelUp, setLevelUp] = useState<boolean>();
   const [gameStatus, setGameStatus] = useState<GameStatus>();
+  const isMobile = useIsMobile();
 
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
@@ -58,12 +60,15 @@ export const ChatView = ({ children }: PropsWithChildren): ReactElement => {
           height: 'auto',
           width: 'auto',
           position: 'absolute',
-          top: (chatHeader?.top ?? 0) + (chatHeader?.height ?? 0),
+          top:
+            (chatHeader?.top ?? 0) +
+            (chatHeader?.height ?? 0) +
+            (isMobile ? 60 : 0),
           right: chatHeader?.x ?? 0,
         }}
       />
     );
-  }, []);
+  }, [isMobile]);
 
   return (
     <>


### PR DESCRIPTION
- call the root redirect to chat in a useEffect
- improve the notes button position for mobile devices
- avoid overlapping from "level up" message and chat header (close: #120)