### PR TITLE
feat: add timeframe filter

### DIFF
--- a/backend/src/main/kotlin/code/nebula/cipherquest/controller/ScoreboardController.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/controller/ScoreboardController.kt
@@ -2,10 +2,12 @@ package code.nebula.cipherquest.controller
 
 import code.nebula.cipherquest.controller.request.Score
 import code.nebula.cipherquest.controller.request.ScoreboardEntry
+import code.nebula.cipherquest.models.TimeFrameFilter
 import code.nebula.cipherquest.service.UserLevelService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -14,7 +16,9 @@ class ScoreboardController(
     private val userLevelService: UserLevelService,
 ) {
     @GetMapping
-    fun getScoreboard(): List<ScoreboardEntry> = userLevelService.calculateScoreboard()
+    fun getScoreboard(
+        @RequestParam(defaultValue = "TODAY") timeFrameFilter: TimeFrameFilter,
+    ): List<ScoreboardEntry> = userLevelService.calculateScoreboard(timeFrameFilter)
 
     @GetMapping("/{id}")
     fun getScore(

--- a/backend/src/main/kotlin/code/nebula/cipherquest/models/TimeFrameFilter.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/models/TimeFrameFilter.kt
@@ -5,4 +5,5 @@ enum class TimeFrameFilter {
     LAST_WEEK,
     LAST_MONTH,
     LAST_YEAR,
+    ALL,
 }

--- a/backend/src/main/kotlin/code/nebula/cipherquest/models/TimeFrameFilter.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/models/TimeFrameFilter.kt
@@ -1,9 +1,27 @@
 package code.nebula.cipherquest.models
 
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+
 enum class TimeFrameFilter {
     TODAY,
     LAST_WEEK,
     LAST_MONTH,
     LAST_YEAR,
     ALL,
+    ;
+
+    fun startDate(): OffsetDateTime =
+        OffsetDateTime
+            .now()
+            .truncatedTo(ChronoUnit.DAYS)
+            .let { offsetDateTime ->
+                when (this@TimeFrameFilter) {
+                    TODAY -> offsetDateTime
+                    LAST_WEEK -> offsetDateTime.minusWeeks(1)
+                    LAST_MONTH -> offsetDateTime.minusMonths(1)
+                    LAST_YEAR -> offsetDateTime.minusYears(1)
+                    ALL -> OffsetDateTime.MIN
+                }
+            }
 }

--- a/backend/src/main/kotlin/code/nebula/cipherquest/models/TimeFrameFilter.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/models/TimeFrameFilter.kt
@@ -1,0 +1,8 @@
+package code.nebula.cipherquest.models
+
+enum class TimeFrameFilter {
+    TODAY,
+    LAST_WEEK,
+    LAST_MONTH,
+    LAST_YEAR,
+}

--- a/backend/src/main/kotlin/code/nebula/cipherquest/repository/UserLevelRepository.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/repository/UserLevelRepository.kt
@@ -3,8 +3,14 @@ package code.nebula.cipherquest.repository
 import code.nebula.cipherquest.repository.entities.UserLevel
 import org.springframework.data.repository.ListCrudRepository
 import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
 
 @Repository
 interface UserLevelRepository : ListCrudRepository<UserLevel, String> {
     fun findFirstByEmail(username: String): UserLevel?
+
+    fun findByUpdatedAtAfterAndScoreGreaterThanOrderByScoreDesc(
+        updatedAtAfter: OffsetDateTime,
+        scoreIsGreaterThan: Long,
+    ): List<UserLevel>
 }

--- a/backend/src/main/resources/http/client.http
+++ b/backend/src/main/resources/http/client.http
@@ -29,7 +29,19 @@ GET http://localhost:8080/api/chat/{{userId}}
 
 ### GET the scoreboard
 
-GET http://localhost:8080/api/score/
+GET http://localhost:8080/api/score
+
+### GET the scoreboard LAST WEEK
+
+GET http://localhost:8080/api/score?timeFrameFilter=LAST_WEEK
+
+### GET the scoreboard LAST MONTH
+
+GET http://localhost:8080/api/score?timeFrameFilter=LAST_MONTH
+
+### GET the scoreboard LAST YEAR
+
+GET http://localhost:8080/api/score?timeFrameFilter=LAST_YEAR
 
 ### POST request with memory id {{userId}}
 


### PR DESCRIPTION
Add the following endpoint with a query param used to filter the score based on the updated_at or terminated_at value of the user_level

GET /api/score (by default TODAY)
GET /api/score?timeFrameFilter=LAST_WEEK
GET /api/score?timeFrameFilter=LAST_MONTH
GET /api/score?timeFrameFilter=LAST_YEAR