### PR TITLE
feat(backend): add prizes creation endpoint

### DIFF
--- a/backend/src/main/kotlin/code/nebula/cipherquest/controller/PrizeController.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/controller/PrizeController.kt
@@ -1,10 +1,15 @@
 package code.nebula.cipherquest.controller
 
+import code.nebula.cipherquest.models.requests.PrizeRequest
 import code.nebula.cipherquest.repository.entities.Prize
 import code.nebula.cipherquest.service.PrizeService
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -16,4 +21,11 @@ class PrizeController(
     fun getPrizes(
         @PathVariable storyName: String,
     ): List<Prize> = prizeService.findAllByCurrentDate(storyName)
+
+    @PostMapping("/{storyName}")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun addPrizes(
+        @PathVariable storyName: String,
+        @RequestBody prizes: List<PrizeRequest>,
+    ): List<Prize> = prizeService.addPrizes(prizes, storyName)
 }

--- a/backend/src/main/kotlin/code/nebula/cipherquest/controller/PrizeController.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/controller/PrizeController.kt
@@ -26,6 +26,6 @@ class PrizeController(
     @ResponseStatus(HttpStatus.CREATED)
     fun addPrizes(
         @PathVariable storyName: String,
-        @RequestBody prizes: List<PrizeRequest>,
+        @RequestBody prizes: PrizeRequest,
     ): List<Prize> = prizeService.addPrizes(prizes, storyName)
 }

--- a/backend/src/main/kotlin/code/nebula/cipherquest/controller/PrizeController.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/controller/PrizeController.kt
@@ -3,6 +3,7 @@ package code.nebula.cipherquest.controller
 import code.nebula.cipherquest.models.requests.PrizeRequest
 import code.nebula.cipherquest.repository.entities.Prize
 import code.nebula.cipherquest.service.PrizeService
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -26,6 +27,6 @@ class PrizeController(
     @ResponseStatus(HttpStatus.CREATED)
     fun addPrizes(
         @PathVariable storyName: String,
-        @RequestBody prizes: PrizeRequest,
+        @RequestBody @Valid prizes: PrizeRequest,
     ): List<Prize> = prizeService.addPrizes(prizes, storyName)
 }

--- a/backend/src/main/kotlin/code/nebula/cipherquest/models/requests/PrizeRequest.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/models/requests/PrizeRequest.kt
@@ -1,0 +1,9 @@
+package code.nebula.cipherquest.models.requests
+
+import java.time.LocalDate
+
+data class PrizeRequest(
+    val name: String,
+    val position: Int,
+    val date: LocalDate = LocalDate.now(),
+)

--- a/backend/src/main/kotlin/code/nebula/cipherquest/models/requests/PrizeRequest.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/models/requests/PrizeRequest.kt
@@ -2,8 +2,12 @@ package code.nebula.cipherquest.models.requests
 
 import java.time.LocalDate
 
-data class PrizeRequest(
+data class Prize(
     val name: String,
     val position: Int,
+)
+
+data class PrizeRequest(
     val date: LocalDate = LocalDate.now(),
+    val prizes: List<Prize>,
 )

--- a/backend/src/main/kotlin/code/nebula/cipherquest/models/requests/PrizeRequest.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/models/requests/PrizeRequest.kt
@@ -1,13 +1,19 @@
 package code.nebula.cipherquest.models.requests
 
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
 import java.time.LocalDate
 
 data class Prize(
+    @field:NotBlank(message = "Prize name cannot be blank")
     val name: String,
     val position: Int,
 )
 
 data class PrizeRequest(
     val date: LocalDate = LocalDate.now(),
+    @field:NotEmpty(message = "Prizes should contain at least one entry")
+    @field:Valid
     val prizes: List<Prize>,
 )

--- a/backend/src/main/kotlin/code/nebula/cipherquest/repository/PrizeRepository.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/repository/PrizeRepository.kt
@@ -11,4 +11,11 @@ interface PrizeRepository : ListCrudRepository<Prize, String> {
         storyName: String,
         date: LocalDate,
     ): List<Prize>
+
+    fun findByNameAndPositionAndDateAndStoryName(
+        name: String,
+        position: Int,
+        date: LocalDate,
+        storyName: String,
+    ): Prize?
 }

--- a/backend/src/main/kotlin/code/nebula/cipherquest/repository/entities/Prize.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/repository/entities/Prize.kt
@@ -1,13 +1,17 @@
 package code.nebula.cipherquest.repository.entities
 
 import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import java.time.LocalDate
+import java.util.UUID
 
 @Entity
 data class Prize(
     @Id
-    var id: String,
+    @GeneratedValue(strategy = GenerationType.UUID)
+    var id: UUID? = null,
     var name: String,
     var storyName: String,
     var position: Int,

--- a/backend/src/main/kotlin/code/nebula/cipherquest/service/PrizeService.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/service/PrizeService.kt
@@ -4,6 +4,7 @@ import code.nebula.cipherquest.models.requests.PrizeRequest
 import code.nebula.cipherquest.repository.PrizeRepository
 import code.nebula.cipherquest.repository.entities.Prize
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
 @Service
@@ -13,6 +14,7 @@ class PrizeService(
     fun findAllByCurrentDate(storyName: String): List<Prize> =
         prizeRepository.findAllByStoryNameAndDateOrderByPositionAsc(storyName, LocalDate.now())
 
+    @Transactional
     fun addPrizes(
         prizes: List<PrizeRequest>,
         storyName: String,

--- a/backend/src/main/kotlin/code/nebula/cipherquest/service/PrizeService.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/service/PrizeService.kt
@@ -19,8 +19,8 @@ class PrizeService(
         prizeRequest: PrizeRequest,
         storyName: String,
     ): List<Prize> {
-        if (prizeRequest.prizes.isEmpty()) {
-            throw IllegalArgumentException("Prizes list cannot be empty")
+        require(prizeRequest.prizes.isNotEmpty()) {
+            "Prizes list cannot be empty"
         }
 
         val takenPositions =

--- a/backend/src/main/kotlin/code/nebula/cipherquest/service/PrizeService.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/service/PrizeService.kt
@@ -16,23 +16,24 @@ class PrizeService(
 
     @Transactional
     fun addPrizes(
-        prizes: List<PrizeRequest>,
+        prizeRequest: PrizeRequest,
         storyName: String,
-    ): List<Prize> =
-        prizes
-            .filter {
-                prizeRepository.findByNameAndPositionAndDateAndStoryName(
-                    it.name,
-                    it.position,
-                    it.date,
-                    storyName,
-                ) == null
+    ): List<Prize> {
+        val takenPositions =
+            prizeRepository
+                .findAllByStoryNameAndDateOrderByPositionAsc(storyName, prizeRequest.date)
+                .map { it.position }
+
+        return prizeRequest.prizes
+            .filterNot {
+                takenPositions.contains(it.position)
             }.map {
                 Prize(
                     name = it.name,
                     position = it.position,
-                    date = it.date,
+                    date = prizeRequest.date,
                     storyName = storyName,
                 )
             }.let { prizeRepository.saveAll(it) }
+    }
 }

--- a/backend/src/main/kotlin/code/nebula/cipherquest/service/PrizeService.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/service/PrizeService.kt
@@ -19,6 +19,10 @@ class PrizeService(
         prizeRequest: PrizeRequest,
         storyName: String,
     ): List<Prize> {
+        if (prizeRequest.prizes.isEmpty()) {
+            throw IllegalArgumentException("Prizes list cannot be empty")
+        }
+
         val takenPositions =
             prizeRepository
                 .findAllByStoryNameAndDateOrderByPositionAsc(storyName, prizeRequest.date)

--- a/backend/src/main/kotlin/code/nebula/cipherquest/service/PrizeService.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/service/PrizeService.kt
@@ -18,7 +18,14 @@ class PrizeService(
         storyName: String,
     ): List<Prize> =
         prizes
-            .map {
+            .filter {
+                prizeRepository.findByNameAndPositionAndDateAndStoryName(
+                    it.name,
+                    it.position,
+                    it.date,
+                    storyName,
+                ) == null
+            }.map {
                 Prize(
                     name = it.name,
                     position = it.position,

--- a/backend/src/main/kotlin/code/nebula/cipherquest/service/PrizeService.kt
+++ b/backend/src/main/kotlin/code/nebula/cipherquest/service/PrizeService.kt
@@ -1,5 +1,6 @@
 package code.nebula.cipherquest.service
 
+import code.nebula.cipherquest.models.requests.PrizeRequest
 import code.nebula.cipherquest.repository.PrizeRepository
 import code.nebula.cipherquest.repository.entities.Prize
 import org.springframework.stereotype.Service
@@ -11,4 +12,18 @@ class PrizeService(
 ) {
     fun findAllByCurrentDate(storyName: String): List<Prize> =
         prizeRepository.findAllByStoryNameAndDateOrderByPositionAsc(storyName, LocalDate.now())
+
+    fun addPrizes(
+        prizes: List<PrizeRequest>,
+        storyName: String,
+    ): List<Prize> =
+        prizes
+            .map {
+                Prize(
+                    name = it.name,
+                    position = it.position,
+                    date = it.date,
+                    storyName = storyName,
+                )
+            }.let { prizeRepository.saveAll(it) }
 }

--- a/backend/src/main/resources/http/client.http
+++ b/backend/src/main/resources/http/client.http
@@ -45,20 +45,22 @@ GET http://localhost:8080/api/prize
 POST http://localhost:8080/api/prize/{{storyName}}
 Content-Type: application/json
 
-[
-  {
-    "name": "Backpack",
-    "position": 2
-  },
-  {
-    "name": "Lego set",
-    "position": 1
-  },
-  {
-    "name": "Water bottle",
-    "position": 3
-  }
-]
+{
+  "prizes": [
+    {
+      "name": "Backpack",
+      "position": 2
+    },
+    {
+      "name": "Lego set",
+      "position": 1
+    },
+    {
+      "name": "Water bottle",
+      "position": 3
+    }
+  ]
+}
 
 ### POST create a new user
 

--- a/backend/src/main/resources/http/client.http
+++ b/backend/src/main/resources/http/client.http
@@ -40,6 +40,26 @@ POST http://localhost:8080/api/rag/load/{{storyName}}
 
 GET http://localhost:8080/api/prize
 
+### POST create prizes
+
+POST http://localhost:8080/api/prize/{{storyName}}
+Content-Type: application/json
+
+[
+  {
+    "name": "Backpack",
+    "position": 2
+  },
+  {
+    "name": "Lego set",
+    "position": 1
+  },
+  {
+    "name": "Water bottle",
+    "position": 3
+  }
+]
+
 ### POST create a new user
 
 POST http://127.0.0.1:8080/api/user/{{storyName}}


### PR DESCRIPTION
Add an endpoint for creating prizes.

How to test: run `POST http://localhost:8080/api/prize/{{storyName}}` in `client.http` and check that the prizes are correctly added to the DB, with the date set to today. Subsequent runs should **not** create duplicate prizes.